### PR TITLE
Writing to log of exceptions on requests to site.

### DIFF
--- a/Framework/DBUtils/DBUtils.psm1
+++ b/Framework/DBUtils/DBUtils.psm1
@@ -165,6 +165,19 @@ Function Attach-Database ($server, $databaseName, $dataFileName, $logFileName)
 
 <#
 	.DESCRIPTION
+		Detach database on specified SQL server.
+#>
+
+Function Detach-Database ($server, $databaseName)
+{
+	"Detaching database - " + $databaseName
+	if ($server.databases[$databaseName] -ne $NULL) {
+		$server.DetachDatabase($databaseName, $false)
+	}
+}
+
+<#
+	.DESCRIPTION
 		Executes SQL file at the specified server / database
 #>
 Function Execute-File ($server, $database, $file) 
@@ -178,4 +191,5 @@ Export-ModuleMember -function Delete-Database
 Export-ModuleMember -function Restore-Database
 Export-ModuleMember -function Backup-Database
 Export-ModuleMember -function Attach-Database
+Export-ModuleMember -function Detach-Database
 Export-ModuleMember -function Execute-File

--- a/Framework/WebUtils/WebUtils.psm1
+++ b/Framework/WebUtils/WebUtils.psm1
@@ -7,9 +7,25 @@ function Get-WebPage {
 	}
 	
 	Write-Output "Creating request to $url"
-	$request = [system.net.WebRequest]::Create($url)
-	$request.Timeout = 2400000
-	return $request.GetResponse()		
+	
+	Try
+	{
+		$request = [system.net.WebRequest]::Create($url)
+		$request.Timeout = 2400000
+		return $request.GetResponse()		
+	}
+	Catch [System.Net.WebException]
+	{
+		#On web exception write response string and throw exception
+		$stream = $_.Exception.Response.GetResponseStream()
+		$reader = new-object -typename System.IO.StreamReader -argumentlist $stream
+		Write-Host $reader.ReadToEnd()
+		Throw $_.Exception
+	}
+	Catch
+	{
+		Throw $_.Exception
+	}
 }
 
 Export-ModuleMember -function Get-WebPage

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Basic DB operations - backup / restore / execute, etc.
 * Restore-Database
 * Backup-Database
 * Attach-Database
+* Detach-Database
 * Execute-File
 
 **FileUtils.psm1**


### PR DESCRIPTION
There was difficulties to find problems when there was exception on
sites after requests from build script. User saw error message with no
details that could be useful. Now, on web exception script writes
response string and then throws exception.
