### PR TITLE
added param DatabasePath to Create-Database

### DIFF
--- a/Framework/DBUtils/DBUtils.psm1
+++ b/Framework/DBUtils/DBUtils.psm1
@@ -10,9 +10,6 @@
 Function Create-Database ($server, $databaseName, $DatabasePath)
 {
     if($DatabasePath) {
-        if(-not (Test-Path $DatabasePath)) {
-            mkdir $DatabasePath | Out-Null
-        }
         $dataFileFolder = $DatabasePath
         $logFileFolder = $DatabasePath
 


### PR DESCRIPTION
Added a parameter "DatabasePath" to Create-Database where you can
overwrite the default setting where the database files (data and log)
should be placed when creating a new database.
