### PR TITLE
Use PowerShell verbs in DBUtils

### DIFF
--- a/Framework/DBUtils/DBUtils.psm1
+++ b/Framework/DBUtils/DBUtils.psm1
@@ -7,7 +7,7 @@
 	.DESCRIPTION
 		Creates new database on specified SQL server. Existing DB will be overwritten
 #>
-Function Create-Database ($server, $databaseName, $DatabasePath)
+Function New-Database ($server, $databaseName, $DatabasePath)
 {
     if($DatabasePath) {
         $dataFileFolder = $DatabasePath
@@ -74,7 +74,7 @@ Function Create-Database ($server, $databaseName, $DatabasePath)
 	.DESCRIPTION
 		Deletes the database on the specified SQL server. 
 #>
-Function Delete-Database ($server, $databaseName)
+Function Remove-Database ($server, $databaseName)
 {
     "Removing the database - " + $databaseName
     IF ($server.databases[$databaseName] -ne $NULL) {
@@ -122,8 +122,8 @@ Function Restore-Database ($server, $database, $backupFile)
 		}
 		[Void]$Restore.RelocateFiles.Add($RestoreData)
 	}
-    
 	$Restore.SqlRestore($server)
+
     "Backup restored: " + $server + $backupFile 
 }
 
@@ -157,7 +157,7 @@ Function Backup-Database ($d, $server, $dbName)
 	.DESCRIPTION
 		Attaches database on specified SQL server. Existing DB will be detached
 #>
-Function Attach-Database ($server, $databaseName, $dataFileName, $logFileName)
+Function Set-Database ($server, $databaseName, $dataFileName, $logFileName)
 {
     if ($server.databases[$databaseName] -ne $NULL) {
         $server.DetachDatabase($databaseName, $false)
@@ -175,15 +175,22 @@ Function Attach-Database ($server, $databaseName, $dataFileName, $logFileName)
 	.DESCRIPTION
 		Executes SQL file at the specified server / database
 #>
-Function Execute-File ($server, $database, $file) 
+Function Invoke-File ($server, $database, $file) 
 {
     Write-Output "Executin Sql file $file at $server/$database"
     Invoke-SqlCmd -inputfile $file -serverinstance $server -database $database
 }
+
+New-Alias -Name Create-Database  -Value New-Database
+New-Alias -Name Delete-Database  -Value Remove-Database
+New-Alias -Name Execute-File  -Value Invoke-File
+New-Alias -Name Attach-Database  -Value Set-Database
   
-Export-ModuleMember -function Create-Database
-Export-ModuleMember -function Delete-Database
+Export-ModuleMember -function New-Database
 Export-ModuleMember -function Restore-Database
+Export-ModuleMember -function Remove-Database
 Export-ModuleMember -function Backup-Database
-Export-ModuleMember -function Attach-Database
-Export-ModuleMember -function Execute-File
+Export-ModuleMember -function Set-Database
+Export-ModuleMember -function Invoke-File
+
+Export-ModuleMember -Alias *


### PR DESCRIPTION
In the DBUtils-Module some functions have unaproved verbs. To follow
PowerShell best practive and to avoid a Warning when importing the Module,
only aproved verbs should be used for advanced functions.
I renamed the functions so that all use approved verbs and created aliases
with the old name to not break compatibility which existing scripts.
